### PR TITLE
Remove linker flag --allow-shlib-undefined

### DIFF
--- a/cmake/ecbuild_check_os.cmake
+++ b/cmake/ecbuild_check_os.cmake
@@ -294,10 +294,6 @@ if( UNIX )
         if( NOT ${_linker_understands_origin} )
           ecbuild_warn( "The linker does not support $ORIGIN at link-time, \
             disabling dynamic symbol check when linking against shared libraries" )
-
-          set(CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS}    -Wl,--allow-shlib-undefined")
-          set(CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
-          set(CMAKE_MODULE_LINKER_FLAGS  "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--allow-shlib-undefined")
         endif()
       endif()
     endif()


### PR DESCRIPTION
Building with ecbuild fails on at least two systems outside of NASA during the
configure stage with these errors:

- Could NOT find MPI_Fortran (missing: MPI_Fortran_WORKS)
- Could NOT find MPI (missing: MPI_Fortran_FOUND) (found version "3.1")

The error can be traced to setting linker flags in ecbuild for use
in the CMake library. Removing the flags solves the issue.

Signed-off-by: Lizzie Lundgren <elundgren@seas.harvard.edu>