### PR TITLE
Update to latest FindNetCDF.cmake from JCSDA

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -5,7 +5,7 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation nor
 # does it submit to any jurisdiction.
-
+#
 # Try to find NetCDF includes and library.
 # Supports static and shared libaries and allows each component to be found in sepearte prefixes.
 #
@@ -148,22 +148,35 @@ foreach( _comp IN LISTS _search_components )
   endif()
   find_program( NetCDF_${_comp}_CONFIG_EXECUTABLE
       NAMES n${_conf}-config
-    HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
-    PATH_SUFFIXES bin Bin ../bin ../../bin
+      HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
+      PATH_SUFFIXES bin Bin ../bin ../../bin
       DOC "NetCDF n${_conf}-config helper" )
     message(DEBUG "NetCDF_${_comp}_CONFIG_EXECUTABLE: ${NetCDF_${_comp}_CONFIG_EXECUTABLE}")
 endforeach()
 
 set(_C_libs_flag --libs)
+set(_C_static_flag --static)
 set(_Fortran_libs_flag --flibs)
 set(_CXX_libs_flag --libs)
 set(_C_includes_flag --includedir)
 set(_Fortran_includes_flag --includedir)
 set(_CXX_includes_flag --includedir)
+# Call n*-config with one argument only (e.g. --libs)
 function(netcdf_config exec flag output_var)
   set(${output_var} False PARENT_SCOPE)
   if( exec )
     execute_process( COMMAND ${exec} ${flag} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
+    if( _ret EQUAL 0 )
+      string( STRIP ${_val} _val )
+      set( ${output_var} ${_val} PARENT_SCOPE )
+    endif()
+  endif()
+endfunction()
+# Call n*-config with two arguments (e.g. --libs --static)
+function(netcdf_config2 exec flag1 flag2 output_var)
+  set(${output_var} False PARENT_SCOPE)
+  if( exec )
+    execute_process( COMMAND ${exec} ${flag1} ${flag2} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
     if( _ret EQUAL 0 )
       string( STRIP ${_val} _val )
       set( ${output_var} ${_val} PARENT_SCOPE )
@@ -216,7 +229,15 @@ foreach( _comp IN LISTS _search_components )
   netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} _val )
   if( _val )
     set( NetCDF_${_comp}_LIBRARIES ${_val} )
-    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND) #Static targets should use nc_config to get a proper link line with all necessary static targets.
+    #Static targets should use nc_config to get a proper link line with all necessary static targets.
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND)
+      #Static netcdf-c uses special flags to add the static libraries (libsprivate)
+      if(${_comp} STREQUAL "C" )
+        netcdf_config2( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} ${_${_comp}_static_flag} _val )
+        if( _val )
+          set( NetCDF_${_comp}_LIBRARIES ${_val} )
+        endif()
+      endif()
       list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
     endif()
   else()


### PR DESCRIPTION
This PR updates the `FindNetCDF.cmake` file to that from JCSDA's [CMakeModules](https://github.com/NOAA-EMC/CMakeModules) repo. 

This update has fixes for using NetCDF static builds.