### PR TITLE
Remove pipe from GNU flags

### DIFF
--- a/cmake/ecbuild_check_compiler.cmake
+++ b/cmake/ecbuild_check_compiler.cmake
@@ -65,6 +65,7 @@ endif()
 
 if( CMAKE_COMPILER_IS_GNUCC )
 
+    # -pipe seems to cause issues with gcc with Xcode 16
     #ecbuild_add_c_flags("-pipe") # use pipe for faster compilation
 
     if( ENABLE_WARNINGS )
@@ -77,6 +78,7 @@ endif()
 
 if( CMAKE_COMPILER_IS_GNUCXX )
 
+   # -pipe seems to cause issues with gcc with Xcode 16
    #ecbuild_add_cxx_flags("-pipe") # use pipe for faster compilation
 
     if( ENABLE_WARNINGS )

--- a/cmake/ecbuild_check_compiler.cmake
+++ b/cmake/ecbuild_check_compiler.cmake
@@ -65,7 +65,7 @@ endif()
 
 if( CMAKE_COMPILER_IS_GNUCC )
 
-    ecbuild_add_c_flags("-pipe") # use pipe for faster compilation
+    #ecbuild_add_c_flags("-pipe") # use pipe for faster compilation
 
     if( ENABLE_WARNINGS )
         ecbuild_add_c_flags("-Wall")
@@ -77,7 +77,7 @@ endif()
 
 if( CMAKE_COMPILER_IS_GNUCXX )
 
-   ecbuild_add_cxx_flags("-pipe") # use pipe for faster compilation
+   #ecbuild_add_cxx_flags("-pipe") # use pipe for faster compilation
 
     if( ENABLE_WARNINGS )
         ecbuild_add_cxx_flags("-Wall")


### PR DESCRIPTION
As found by @tclune and @gmao-ckung, XCode 16 on macOS has caused an issue where the `-pipe` GNU compiler flag causes errors in CMake builds.

It doesn't seem to be crucial and research online says the pipe flag isn't really that crucial for fast builds anymore. 